### PR TITLE
forcing framebuffer flags to make desltop fb0 usable

### DIFF
--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -23,6 +23,8 @@ impl Framebuffer {
 
     pub fn setup(&self) -> Result<(),Box<dyn Error>> {
         framebuffer::Framebuffer::set_kd_mode(framebuffer::KdMode::Graphics)?;
+        // force the framebuffer to activate
+        // https://unix.stackexchange.com/questions/58420/writes-to-framebuffer-dev-fb0-do-not-seem-to-change-graphics-screen
         let mut screen = framebuffer::Framebuffer::get_var_screeninfo(&self.fb.device)?;
         screen.activate |= FB_ACTIVATE_NOW | FB_ACTIVATE_FORCE; 
         framebuffer::Framebuffer::put_var_screeninfo(&self.fb.device,&screen)?;

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -5,6 +5,8 @@ use std::path::Path;
 pub struct Framebuffer {
     fb: framebuffer::Framebuffer,
 }
+const FB_ACTIVATE_NOW:u32 = 0;
+const FB_ACTIVATE_FORCE:u32 = 128;
 
 impl Framebuffer {
     pub fn new<P: AsRef<Path>>(path_to_framebuffer: P) -> Result<Self, Box<dyn Error>> {
@@ -19,8 +21,12 @@ impl Framebuffer {
         })
     }
 
-    pub fn setup(&self) {
-        framebuffer::Framebuffer::set_kd_mode(framebuffer::KdMode::Graphics).unwrap();
+    pub fn setup(&self) -> Result<(),Box<dyn Error>> {
+        framebuffer::Framebuffer::set_kd_mode(framebuffer::KdMode::Graphics)?;
+        let mut screen = framebuffer::Framebuffer::get_var_screeninfo(&self.fb.device)?;
+        screen.activate |= FB_ACTIVATE_NOW | FB_ACTIVATE_FORCE; 
+        framebuffer::Framebuffer::put_var_screeninfo(&self.fb.device,&screen)?;
+        Ok(())
     }
 
     pub fn shutdown(&self) {


### PR DESCRIPTION
for the longest while I wasn't able to run examples on my laptop, I figured out some secret codes to make it work

https://unix.stackexchange.com/questions/58420/writes-to-framebuffer-dev-fb0-do-not-seem-to-change-graphics-screen

it works! :) 
