### PR TITLE
Layers

### DIFF
--- a/examples/drag.rs
+++ b/examples/drag.rs
@@ -10,6 +10,14 @@ fn main() {
 
     d.run(|canvas, swipe, delta_time| {
         debug!("Enter callback");
+        if canvas.layers.len() < 2 {
+            canvas.new_layer();
+            canvas.new_layer();
+        }
+
+        debug!("Begin flush");
+        canvas.flush(0);
+        debug!("End flush");
         if let Some(swipe) = swipe {
             debug!("New swipe");
             let points = swipe.points.clone();
@@ -19,8 +27,7 @@ fn main() {
             }
             debug!("{:?}", swipe.drag());
             if let Some(Gesture::Drag(point0, point1)) = swipe.drag() {
-                debug!("Draw line");
-                canvas.plot_line(point0, point1);
+                canvas.plot_line(0, point0, point1);
             }
         }
         Ok(RunResponse::Draw)

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,6 +1,8 @@
 use crate::point::Point;
 use std::error::Error;
 
+use crate::layer::*;
+
 #[derive(Debug)]
 pub struct Canvas {
     pub width: usize,
@@ -8,18 +10,23 @@ pub struct Canvas {
     pub pixels: Vec<u8>,
     pub line_length: usize,
     pub bytespp: usize,
+    pub layers: Vec<Layer>,
+    pub background: Pixel,
 }
 
 impl Canvas {
     pub fn new(width: usize, height: usize, pixels: &[u8]) -> Result<Self, Box<dyn Error>> {
         let bytespp = pixels.len() / (width * height);
         let line_length = bytespp * width;
+        let first_layer = Vec::<Layer>::new();
         Ok(Canvas {
             pixels: pixels.to_owned(),
             width,
             height,
             line_length,
             bytespp,
+            layers: first_layer,
+            background: Pixel { r: 0, g: 0, b: 0 },
         })
     }
 
@@ -32,7 +39,7 @@ impl Canvas {
         )
     }
 
-    pub fn set_pixel(&mut self, x: usize, y: usize, r: u8, g: u8, b: u8) {
+    fn set_raw_pixel(&mut self, x: usize, y: usize, r: u8, g: u8, b: u8) {
         let curr_index = y * self.line_length + x * self.bytespp;
         self.pixels[curr_index] = r;
         self.pixels[curr_index + 1] = g;
@@ -60,7 +67,63 @@ impl Canvas {
         Ok(())
     }
 
-    pub fn plot_line(&mut self, point0: Point, point1: Point) {
+    pub fn new_layer(&mut self) {
+        let layer = Layer {
+            pixels: vec![None; self.width * self.height],
+            width: self.width,
+            height: self.height,
+        };
+        self.layers.push(layer);
+    }
+
+    fn flatten_pixel(&mut self, x: usize, y: usize) {
+        let nlayers = self.layers.len();
+        let mut long_pixel = &self.background;
+        for i in 0..nlayers - 1 {
+            if let Some(px) = self.layers[i].get_pixel(x, y).as_ref() {
+                long_pixel = px;
+                break;
+            }
+        }
+
+        self.set_raw_pixel(x, y, long_pixel.r, long_pixel.g, long_pixel.b);
+    }
+
+    // fn flatten_layers(&mut self) {
+    //     for x in 0..self.width - 1 {
+    //         for y in 0..self.height - 1 {
+    //             let Pixel { r, g, b } = self.flatten_pixel(x, y);
+    //             self.set_pixel(x, y, *r, *g, *b);
+    //         }
+    //     }
+    // }
+
+    pub fn pixels(&mut self) -> &Vec<u8> {
+        // self.flatten_layers();
+        &self.pixels
+    }
+
+    pub fn set_pixel(&mut self, layer: usize, x: usize, y: usize, r: u8, g: u8, b: u8) {
+        self.layers[layer].set_pixel(x, y, r, g, b);
+        self.flatten_pixel(x, y);
+    }
+
+    pub fn unset_pixel(&mut self, layer: usize, x: usize, y: usize) {
+        if let Some(_) = self.layers[layer].get_pixel(x, y).as_ref() {
+            self.layers[layer].unset_pixel(x, y);
+            self.flatten_pixel(x, y);
+        }
+    }
+
+    pub fn flush(&mut self, layer: usize) {
+        for x in 0..self.width - 1 {
+            for y in 0..self.height - 1 {
+                self.unset_pixel(layer, x, y);
+            }
+        }
+    }
+
+    pub fn plot_line(&mut self, layer: usize, point0: Point, point1: Point) {
         let mut x0 = point0.x as isize;
         let mut y0 = point0.y as isize;
         let x1 = point1.x as isize;
@@ -71,19 +134,18 @@ impl Canvas {
         let sy = if y0 < y1 { 1 } else { -1 };
         let mut err = dx + dy; /* error value e_xy */
         loop {
-            /* loop */
-            self.set_pixel(x0 as usize, y0 as usize, 255, 255, 255);
+            self.set_pixel(layer, x0 as usize, y0 as usize, 255, 255, 255);
             if x0 == x1 && y0 == y1 {
                 break;
             }
             let e2 = 2 * err;
             if e2 >= dy {
-                /* e_xy+e_x > 0 */
+                // e_xy+e_x > 0
                 err += dy;
                 x0 += sx;
             }
             if e2 <= dx {
-                /* e_xy+e_y < 0 */
+                // e_xy+e_y < 0
                 err += dx;
                 y0 += sy;
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,9 +6,11 @@ use std::time::Instant;
 
 use crate::input::event_input::EventInput;
 use crate::input::InputEvent;
+use crate::layer::*;
 use crate::point::*;
 use crate::streamed_data::*;
 use crate::swipe::*;
+
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -76,6 +78,8 @@ impl Config {
             line_length,
             bytespp: fb.bytes_per_pixel(),
             pixels: vec![0u8; line_length * h],
+            layers: Vec::<Layer>::new(),
+            background: Pixel { r: 0, g: 0, b: 0 },
         };
 
         fb.setup();
@@ -90,7 +94,7 @@ impl Config {
             eprintln!("Error occured in user run loop: {}", err);
             std::process::exit(0);
         }
-        fb.write_frame(&canvas.pixels);
+        fb.write_frame(canvas.pixels());
         if let Ok(RunResponse::Exit) = run_response {
             fb.shutdown();
             std::process::exit(0);
@@ -127,7 +131,8 @@ impl Config {
             }
 
             if let Ok(RunResponse::Draw) = run_response {
-                fb.write_frame(&canvas.pixels);
+                let pixels = canvas.pixels();
+                fb.write_frame(pixels);
             } else if let Ok(RunResponse::Exit) = run_response {
                 fb.shutdown();
                 std::process::exit(0);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,6 +2,7 @@ use crate::point::Timeval;
 
 pub mod event_input;
 
+#[derive(Debug, Clone)]
 pub enum InputEvent {
     PartialX(isize, Timeval),
     PartialY(isize, Timeval),

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,0 +1,33 @@
+use crate::canvas::*;
+use crate::point::*;
+
+#[derive(Debug, Clone)]
+pub struct Pixel {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct Layer {
+    pub pixels: Vec<Option<Pixel>>,
+    pub width: usize,
+    pub height: usize,
+}
+
+impl Layer {
+    pub fn get_pixel(&self, x: usize, y: usize) -> &Option<Pixel> {
+        let index = y * self.width + x;
+        &self.pixels[index]
+    }
+
+    pub fn set_pixel(&mut self, x: usize, y: usize, r: u8, g: u8, b: u8) {
+        let index = y * self.width + x;
+        self.pixels[index] = Some(Pixel { r, g, b })
+    }
+
+    pub fn unset_pixel(&mut self, x: usize, y: usize) {
+        let index = y * self.width + x;
+        self.pixels[index] = None;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod framebuffer;
 pub mod gesture;
 pub mod input;
+pub mod layer;
 pub mod point;
 pub mod prelude;
 pub mod streamed_data;


### PR DESCRIPTION
Here is a PR so that we can study difficulties related to #9.

`Canvas` holds a vec of `Layer`. Layers are meant to represent a depth in the scene to draw. Each layer has an array of `Option<Pixel>` representing whether a layer has something to display on a particular pixel. They are meant to be ordered so that only the top-most layer is will actually be displayed.

I think eventually it'd be best that each layer has a reference to the canvas that holds it so that we can manipulate the layers on their own. In the approach I took it is necessary to go through the canvas because I attempt to keep the canvas' pixels up to date regarding which is the top-most pixel as I update some layer's pixel. I went this way because for-looping the whole thing to determine the top-most pixels  each time I want to display was way too slow. However in the drag example I want to clear a layer from the line drawn at the previous iteration. I used a for-loop and this step makes it very slow. I'm not sure what to do. Maybe use a map of coordinated -> pixels so that active pixels of a layer are easily accessible without need to go through the whole thing? It doesn't seem convenient though. I am also worried that we might eventually run into this problem anyway at some point since writing something on the whole screen does seem like something trivial one would want to do. How is the `helloworld` example actually performing since that's what it does?